### PR TITLE
Feature/error handling

### DIFF
--- a/cloudbolt.gemspec
+++ b/cloudbolt.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'cloudbolt'
-  s.version     = '0.0.4'
-  s.date        = '2019-01-31'
+  s.version     = '0.0.5'
+  s.date        = '2019-03-15'
   s.summary     = 'CloudBolt Ruby Library'
   s.description = 'A gem to interface with the CloudBolt REST API'
   s.authors     = 'Adam Kinney'

--- a/lib/cloudbolt.rb
+++ b/lib/cloudbolt.rb
@@ -20,6 +20,7 @@ module CloudboltAPI
       headers = {"Content-Type" => "application/json"}
       url = "#{@proto}://#{@host}:#{@port}/api/v2/api-token-auth/"
       response = HTTParty.post(url, :verify => @ssl_verify, :headers => headers, :body => body.to_json)
+      raise TokenRetrievalError, 'Error retrieving API token' unless response['token']
       return response['token']
     end
 
@@ -37,14 +38,14 @@ module CloudboltAPI
       order_id = order["_links"]["self"]["title"][/\d+/].to_i
       completed = ['SUCCESS', 'WARNING', 'FAILURE']
       status = nil
-      print "Waiting for Order #{order_id} to complete: "
+      puts "Waiting for Order #{order_id} to complete: "
       until completed.include? status
         order = get_order(order_id)
         status = order["status"]
         print "."
         sleep(wait_time)
       end
-      puts " Order Complete!"
+      puts " Order finished with status #{status}!"
     end
 
     def get_server(server_id)
@@ -90,7 +91,7 @@ module CloudboltAPI
       headers["Authorization"] = "Bearer " + @token
       response = HTTParty.post(url, :verify => @ssl_verify, :headers => headers, :body => order.to_json)
       prov = JSON.parse(response.body)
-
+      raise OrderSubmissionError, "Unable to Submit Order: #{prov['error']}" if prov['error']
       if wait
         wait_for_complete(url, headers, prov, wait_time)
       end
@@ -110,11 +111,21 @@ module CloudboltAPI
       response = HTTParty.post(url, :verify => @ssl_verify, :headers => headers, :body => order.to_json)
       decom = JSON.parse(response.body)
 
+      raise OrderSubmissionError, "Unable to Submit Order: #{decom['error']}" if decom['error']
       if wait
         wait_for_complete(url, headers, decom, wait_time)
       end
 
       return decom
     end
+  end
+
+  class CloudboltRuntimeError < RuntimeError
+  end
+
+  class OrderSubmissionError < CloudboltRuntimeError
+  end
+
+  class TokenRetrievalError < CloudboltRuntimeError
   end
 end

--- a/lib/cloudbolt.rb
+++ b/lib/cloudbolt.rb
@@ -33,6 +33,21 @@ module CloudboltAPI
       return response
     end
 
+    def get_order_log_message(order)
+      jobs = order["_links"]["jobs"]
+      message = nil
+      for job in jobs do
+        job_url = "#{@proto}://#{@host}:#{@port}#{job["href"]}"
+        headers = { 'Content-Type' => 'application/json' }
+        headers['Authorization'] = "Bearer #{@token}"
+        response = HTTParty.get(job_url, :verify => @ssl_verify, :headers => headers)
+        # return if this job is a build or destroy job
+        return response['progress']['messages'][-1] if ['Provision Server', 'Delete Server'].include?(response['type'])
+      end
+      # if neither significant job was found, print a placeholder
+      return 'Waiting for job status'
+    end
+
     def wait_for_complete(url, headers, order, wait_time=5)
       # Wait until the order submit completes
       order_id = order["_links"]["self"]["title"][/\d+/].to_i
@@ -42,7 +57,7 @@ module CloudboltAPI
       until completed.include? status
         order = get_order(order_id)
         status = order["status"]
-        print "."
+        puts get_order_log_message(order)
         sleep(wait_time)
       end
       puts " Order finished with status #{status}!"


### PR DESCRIPTION
The gem works quite well for testing builds, but whenever Cloudbolt or the user does something unexpected, it usually results in a vague nilClass error. This PR adds some exceptions for common errors (bad credentials, unable to submit order) and also makes the logging a little more descriptive so you can see what the build is doing.